### PR TITLE
added a new version dependancy to leverage webpack 4 instead of 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "standard": "10.0.3"
   },
   "dependencies": {
-    "@cypress/webpack-preprocessor": "1.1.3",
+    "@cypress/webpack-preprocessor": "4.0.3",
     "am-i-a-dependency": "1.1.2",
     "chalk": "2.3.1",
     "debug": "3.1.0",


### PR DESCRIPTION
When I use your library inside a webpack 4-based project I got an error, I fixed and tested it