### PR TITLE
update add-plugin to use env.INIT_CWD for root

### DIFF
--- a/src/add-plugin.js
+++ b/src/add-plugin.js
@@ -16,7 +16,8 @@ if (amDependency) {
 
   // during NPM post install phase it is running in
   // node_modules/@bahmutov/add-typescript-to-cypress
-  const root = path.join(process.cwd(), '..', '..', '..')
+  const root =
+    process.env.INIT_CWD || path.join(process.cwd(), '..', '..', '..')
   const cypressFolder = path.join(root, 'cypress')
   const pluginsFolder = path.join(cypressFolder, 'plugins')
   const ourPreprocessorFilename = path.join(


### PR DESCRIPTION
The purpose of this is to better handle when using environments that cache the node_modules folder by symlinking (ie. AWS CodeBuild cache). By using `process.env.INIT_CWD` we save the need to have to climb up the directory tree to try and get to the root folder. This would probably also help if this library was somehow used as a sub-module